### PR TITLE
Fix typo on profile page

### DIFF
--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -26,8 +26,8 @@ export const ProfilePage = () => {
     <Text mt={15}>Registration time: {format(registrationTime, "d.M.yyyy HH:mm")}</Text>
     <Group direction="column" mt={40} spacing={15}>
       <WithTooltip
-        tooltipLabel={<Text>This token is used for authentication in your code editor.
-          <Anchor component={Link} to="/extensions"> Get your extension from here!</Anchor>
+        tooltipLabel={<Text>This token is used for authentication in your code editor.{" "}
+          <Anchor component={Link} to="/extensions">Get your extension from here!</Anchor>
         </Text>}
       >
         <Title order={3}>Authentication token</Title>

--- a/src/components/pages/ProfilePage.tsx
+++ b/src/components/pages/ProfilePage.tsx
@@ -27,7 +27,7 @@ export const ProfilePage = () => {
     <Group direction="column" mt={40} spacing={15}>
       <WithTooltip
         tooltipLabel={<Text>This token is used for authentication in your code editor.
-          <Anchor component={Link} to="/extensions">Get your extension from here!</Anchor>
+          <Anchor component={Link} to="/extensions"> Get your extension from here!</Anchor>
         </Text>}
       >
         <Title order={3}>Authentication token</Title>


### PR DESCRIPTION
Adds a space before the link here
![image](https://user-images.githubusercontent.com/57452544/167910349-8f0d6dda-52bd-49b7-ba25-078dd425f99a.png)

Prior:
![image](https://user-images.githubusercontent.com/57452544/167910443-4f94e452-102a-4941-bd3c-77214941f3e9.png)
