### PR TITLE
Route for logging into IDE extensions using custom URL scheme

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -298,5 +298,13 @@
         "button": "Search"
       }
     }
+  },
+  "authorize": {
+    "body": "You are logging in to the official Visual Studio Code extension.",
+    "continue": "Continue as {{username}}",
+    "notWorking": {
+      "text": "Not working?",
+      "link": "Copy authentication token on settings page."
+    }
   }
 }

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -298,5 +298,13 @@
         "button": "Etsi"
       }
     }
+  },
+  "authorize": {
+    "body": "Olet kirjautumassa sisään viralliseen Visual Studio Code -lisäosaan.",
+    "continue": "Jatka käyttäjänä {{username}}",
+    "notWorking": {
+      "text": "Eikö toimi?",
+      "link": "Kopioi tunnistautumistunnus asetukset-sivulla." 
+    }
   }
 }

--- a/src/app/[locale]/authorize/page.tsx
+++ b/src/app/[locale]/authorize/page.tsx
@@ -1,0 +1,53 @@
+import { Text, Button, Stack } from "@mantine/core";
+import initTranslations from "../../i18n";
+import { cookies } from "next/headers";
+import { getMe } from "../../../api/usersApi";
+import { redirect } from "next/navigation";
+import Image from "next/image";
+import Link from "next/link";
+
+export default async function AuthorizePage({
+  params: { locale },
+  searchParams: { editor },
+}: {
+  params: { locale: string };
+  searchParams: { editor?: string };
+}) {
+  const { t } = await initTranslations(locale, ["common"]);
+
+  const loginUrl =
+    editor == "vscode"
+      ? `/login?redirect=${encodeURIComponent("/authorize?editor=vscode")}`
+      : "/login";
+
+  const token = cookies().get("token")?.value;
+  if (!token) {
+    redirect(loginUrl);
+  }
+
+  const me = await getMe();
+  if (!me || "error" in me) {
+    redirect(loginUrl);
+  }
+
+  const { username } = me;
+
+  return (
+    <Stack align="center" gap="xl">
+      <Image
+        src="/images/vscode.svg"
+        alt="Visual Studio Code"
+        width={40}
+        height={40}
+      />
+      <Text>{t("authorize.body")}</Text>
+      <a href={`vscode://testausserveri-ry.testaustime/authorize?${token}`}>
+        <Button>{t("authorize.continue", { username })}</Button>
+      </a>
+      <Text c="dark.2">
+        {t("authorize.notWorking.text")}&nbsp;
+        <Link href="profile">{t("authorize.notWorking.link")}</Link>
+      </Text>
+    </Stack>
+  );
+}

--- a/src/app/[locale]/authorize/page.tsx
+++ b/src/app/[locale]/authorize/page.tsx
@@ -41,9 +41,12 @@ export default async function AuthorizePage({
         height={40}
       />
       <Text>{t("authorize.body")}</Text>
-      <a href={`vscode://testausserveri-ry.testaustime/authorize?${token}`}>
-        <Button>{t("authorize.continue", { username })}</Button>
-      </a>
+      <Button
+        component="a"
+        href={`vscode://testausserveri-ry.testaustime/authorize?token=${token}`}
+      >
+        {t("authorize.continue", { username })}
+      </Button>
       <Text c="dark.2">
         {t("authorize.notWorking.text")}&nbsp;
         <Link href="profile">{t("authorize.notWorking.link")}</Link>

--- a/src/components/LoginForm/actions.ts
+++ b/src/components/LoginForm/actions.ts
@@ -17,7 +17,7 @@ export interface SecureAccessTokenResponse {
   token: string;
 }
 
-const allowedRedirects = ["/profile", "/friends", "/leaderboards"];
+const allowedRedirects = ["/profile", "/friends", "/leaderboards", "/authorize?editor=vscode"];
 
 export const logIn = async (
   username: string,

--- a/src/components/LoginForm/actions.ts
+++ b/src/components/LoginForm/actions.ts
@@ -17,7 +17,12 @@ export interface SecureAccessTokenResponse {
   token: string;
 }
 
-const allowedRedirects = ["/profile", "/friends", "/leaderboards", "/authorize?editor=vscode"];
+const allowedRedirects = [
+  "/profile",
+  "/friends",
+  "/leaderboards",
+  "/authorize?editor=vscode",
+];
 
 export const logIn = async (
   username: string,


### PR DESCRIPTION
In case user is logged out it redirects the user to log in and back to the authorize route.

<img width="897" alt="Screenshot 2024-01-03 at 22 47 01" src="https://github.com/Testaustime/testaustime-frontend/assets/46541386/deb771bb-90d5-4530-a694-84bcdbbc8168">

See also: PR for testaustime-vscode
https://github.com/Testaustime/testaustime-vscode/pull/11