### PR TITLE
fix: correct graph title

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -27,6 +27,7 @@
       "week": "Last 7 days"
     },
     "timePerDay": "Time per day",
+    "timePerMonth": "Time per month",
     "timePerProject": "Time per project",
     "totalTime": "Total time coded in the last {{days}} days: {{totalTime}}",
     "unknownProject": "Unknown"

--- a/public/locales/fi/common.json
+++ b/public/locales/fi/common.json
@@ -27,6 +27,7 @@
       "week": "Viimeiset 7 päivää"
     },
     "timePerDay": "Aika per päivä",
+    "timePerMonth": "Aika per kuukausi",
     "timePerProject": "Aika per projekti",
     "totalTime": "Kokonaisaika viimeisten {{days}} päivän aikana: {{totalTime}}",
     "unknownProject": "Tuntematon"

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -222,7 +222,9 @@ export const Dashboard = ({
         <>
           <DataCard>
             <Title mt={10} order={2}>
-              {t("dashboard.timePerDay")}
+              {dayCount > 180
+                ? t("dashboard.timePerMonth")
+                : t("dashboard.timePerDay")}
             </Title>
             {entries.length > 0 ? (
               dayCount > 180 ? (


### PR DESCRIPTION
Currently, the graph title on the dashboard always displays "Time per day", even though a per-month graph is used when the graph has over 180 days of data.

With this PR a "Time per month" title will be shown instead in such cases