### PR TITLE
Fix chart smoothing overshoot

### DIFF
--- a/src/components/DailyCodingTimeChart/DailyCodingTimeChart.tsx
+++ b/src/components/DailyCodingTimeChart/DailyCodingTimeChart.tsx
@@ -111,9 +111,7 @@ export const DailyCodingTimeChart = ({
             borderWidth: 4,
             pointRadius: 2,
             // Avoid "overshoot" where the smoothed curve goes above/below actual points.
-            cubicInterpolationMode: smoothCharts
-              ? ("monotone" as const)
-              : ("default" as const),
+            cubicInterpolationMode: smoothCharts ? "monotone" : "default",
             tension: smoothCharts ? 0.5 : 0,
           },
         ],

--- a/src/components/DailyCodingTimeChart/DailyCodingTimeChart.tsx
+++ b/src/components/DailyCodingTimeChart/DailyCodingTimeChart.tsx
@@ -110,6 +110,10 @@ export const DailyCodingTimeChart = ({
             borderColor: "#1f78b4",
             borderWidth: 4,
             pointRadius: 2,
+            // Avoid "overshoot" where the smoothed curve goes above/below actual points.
+            cubicInterpolationMode: smoothCharts
+              ? ("monotone" as const)
+              : ("default" as const),
             tension: smoothCharts ? 0.5 : 0,
           },
         ],

--- a/src/components/MonthlyCodingTimeChart/MonthlyCodingTimeChart.tsx
+++ b/src/components/MonthlyCodingTimeChart/MonthlyCodingTimeChart.tsx
@@ -120,6 +120,10 @@ export const MonthlyCodingTimeChart = ({
             borderColor: "#1f78b4",
             borderWidth: 4,
             pointRadius: 2,
+            // Avoid "overshoot" where the smoothed curve goes above/below actual points.
+            cubicInterpolationMode: smoothCharts
+              ? ("monotone" as const)
+              : ("default" as const),
             tension: smoothCharts ? 0.5 : 0,
           },
         ],

--- a/src/components/MonthlyCodingTimeChart/MonthlyCodingTimeChart.tsx
+++ b/src/components/MonthlyCodingTimeChart/MonthlyCodingTimeChart.tsx
@@ -121,9 +121,7 @@ export const MonthlyCodingTimeChart = ({
             borderWidth: 4,
             pointRadius: 2,
             // Avoid "overshoot" where the smoothed curve goes above/below actual points.
-            cubicInterpolationMode: smoothCharts
-              ? ("monotone" as const)
-              : ("default" as const),
+            cubicInterpolationMode: smoothCharts ? "monotone" : "default",
             tension: smoothCharts ? 0.5 : 0,
           },
         ],


### PR DESCRIPTION
Closes #497 

This fixes the “wonky” Chart.js smoothing where the smoothed line can overshoot above the real max data point.
Change: Use Chart.js monotone cubic interpolation (cubicInterpolationMode: "monotone") when “Smooth charts” is enabled.

Affected charts:
Daily coding time chart
Monthly coding time chart

Screenshots:

- Before
<img width="2553" height="1258" alt="Screenshot 2025-12-20 at 7 24 34 AM" src="https://github.com/user-attachments/assets/13e2de17-d01f-439a-bd34-9189afbb7640" />
- After
<img width="2553" height="1254" alt="Screenshot 2025-12-20 at 7 25 04 AM" src="https://github.com/user-attachments/assets/271e3117-9856-4c15-867a-ecb0230ea6e6" />
