### PR TITLE
Fix chart vertex spikes when smooth charts are disabled

### DIFF
--- a/src/components/DailyCodingTimeChart/DailyCodingTimeChart.tsx
+++ b/src/components/DailyCodingTimeChart/DailyCodingTimeChart.tsx
@@ -109,6 +109,9 @@ export const DailyCodingTimeChart = ({
             data: data.map((entry) => entry.duration),
             borderColor: "#1f78b4",
             borderWidth: 4,
+            // Avoid sharp "miter" spikes at vertices when drawing straight segments.
+            borderJoinStyle: "round",
+            borderCapStyle: "round",
             pointRadius: 2,
             // Avoid "overshoot" where the smoothed curve goes above/below actual points.
             cubicInterpolationMode: smoothCharts ? "monotone" : "default",

--- a/src/components/MonthlyCodingTimeChart/MonthlyCodingTimeChart.tsx
+++ b/src/components/MonthlyCodingTimeChart/MonthlyCodingTimeChart.tsx
@@ -119,6 +119,9 @@ export const MonthlyCodingTimeChart = ({
             data: data.map((entry) => entry.duration),
             borderColor: "#1f78b4",
             borderWidth: 4,
+            // Avoid sharp "miter" spikes at vertices when drawing straight segments.
+            borderJoinStyle: "round",
+            borderCapStyle: "round",
             pointRadius: 2,
             // Avoid "overshoot" where the smoothed curve goes above/below actual points.
             cubicInterpolationMode: smoothCharts ? "monotone" : "default",

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -9,8 +9,9 @@ import {
 import { isDayRange, TimeUnit } from "./dateUtils";
 
 export const getPreferences = () => {
-  const uncheckedDefaultDayRange = cookies().get(defaultDayRangeCookieName)
-    ?.value;
+  const uncheckedDefaultDayRange = cookies().get(
+    defaultDayRangeCookieName,
+  )?.value;
   const defaultDayRange = isDayRange(uncheckedDefaultDayRange)
     ? uncheckedDefaultDayRange
     : undefined;

--- a/src/utils/cookieUtils.ts
+++ b/src/utils/cookieUtils.ts
@@ -9,9 +9,8 @@ import {
 import { isDayRange, TimeUnit } from "./dateUtils";
 
 export const getPreferences = () => {
-  const uncheckedDefaultDayRange = cookies().get(
-    defaultDayRangeCookieName,
-  )?.value;
+  const uncheckedDefaultDayRange = cookies().get(defaultDayRangeCookieName)
+    ?.value;
   const defaultDayRange = isDayRange(uncheckedDefaultDayRange)
     ? uncheckedDefaultDayRange
     : undefined;


### PR DESCRIPTION
Closes #499 

Fixes a Chart.js rendering artifact where thick, non-smoothed line segments can create tiny “needle” spikes at sharp vertices (miter join behavior), as seen in issue #499 .

Change: Set borderJoinStyle: "round" and borderCapStyle: "round" for the daily and monthly line charts to eliminate the vertex spike artifacts.

Files:
`src/components/DailyCodingTimeChart/DailyCodingTimeChart.tsx`
`src/components/MonthlyCodingTimeChart/MonthlyCodingTimeChart.tsx`
Notes: Includes a small formatting tweak in `src/utils/cookieUtils.ts` to keep `npm run lint` passing.

Screenshots:

Before
<img width="2525" height="1211" alt="Screenshot 2025-12-20 at 8 43 38 AM" src="https://github.com/user-attachments/assets/19d02210-834f-40e0-81fa-8aed6828edc3" />
<img width="2541" height="1215" alt="Screenshot 2025-12-20 at 8 44 09 AM" src="https://github.com/user-attachments/assets/fff00036-c55e-4d4e-b3e5-32bb86dd74c4" />