### PR TITLE
Remove country flags from language selector

### DIFF
--- a/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/src/components/LanguageSelector/LanguageSelector.tsx
@@ -33,8 +33,8 @@ export const LanguageSelector = ({
   const id = useId();
 
   const data = [
-    { label: "🇺🇸 English", value: "en" },
-    { label: "🇫🇮 Suomi", value: "fi" },
+    { label: "English", value: "en" },
+    { label: "Suomi", value: "fi" },
   ];
 
   const onChange = (value: string | null) => {


### PR DESCRIPTION
Flags do not correspond to languages and will cause problems with internationalisation if new languages are ever added. For example, Bengali is spoken widely in both India and Bangladesh.

fixes #501 